### PR TITLE
Use double brackets

### DIFF
--- a/content/opt/icinga2/initdocker
+++ b/content/opt/icinga2/initdocker
@@ -67,7 +67,7 @@ if [ ! -f "${initfile}" ]; then
         touch ${initfile}
 fi
 
-if [ -n $ICINGA2_FEATURE_GRAPHITE ]; then
+if [[ -n $ICINGA2_FEATURE_GRAPHITE ]]; then
   echo_log "Enabling Icinga 2 Graphite feature."
   icinga2 feature enable graphite
 


### PR DESCRIPTION
Otherwise it is always evaluated as **true**

An alternative could have been `[ -n "$ICINGA2_FEATURE_GRAPHITE" ]`
