### PR TITLE
Correct Icinga Demo URL

### DIFF
--- a/content/etc/icinga2/conf.d/hosts.conf
+++ b/content/etc/icinga2/conf.d/hosts.conf
@@ -58,8 +58,8 @@ object Host NodeName {
     http_vhost = "exchange.icinga.com"
   }
   vars.http_vhosts["http Icinga Demo"] = {
-    http_address = "demo.icinga.com"
-    http_vhost = "demo.icinga.com"
+    http_address = "www.icinga.com"
+    http_uri = "/demo"
   }
   vars.http_vhosts["http Icinga GitHub"] = {
     http_address = "github.com"


### PR DESCRIPTION
Default check for "http Icinga Demo" tries to load http://demo.icinga.com, which does not seem to exist. Changed it to http://www.icinga.com/demo.